### PR TITLE
fix: add support for page at the root of app folder

### DIFF
--- a/lib/rules/no-use-client-on-page.js
+++ b/lib/rules/no-use-client-on-page.js
@@ -9,7 +9,7 @@ module.exports = {
         fixable: null,
         schema: [],
         messages: {
-            noUseClient: 'Error: "use client" should not be used at the top of a "page" or "pages" file inside the "app" subfolder.',
+            noUseClient: 'Error: "use client" should not be used at the top of a "page" or "pages" file inside the "app" folder & subfolders.',
         },
     },
 
@@ -18,8 +18,8 @@ module.exports = {
 
         return {
             Program(node) {
-                // Check if the file is inside an 'app' subfolder and ends with 'page.ts', 'page.js', 'pages.tsx', or 'pages.jsx'
-                if (!filename.match(/\/app\/.*\/pages?\.(ts|js|tsx|jsx)$/)) {
+                // Check if the file is inside an 'app' folder & subfolders and ends with 'page.ts', 'page.js', 'pages.tsx', or 'pages.jsx'
+                if (!filename.match(/\/app\/.*(?<=\/)pages?\.(ts|js|tsx|jsx)$/)) {
                     return;
                 }
 

--- a/tests/lib/rules/no-client-on-page.test.js
+++ b/tests/lib/rules/no-client-on-page.test.js
@@ -1,5 +1,5 @@
 const { RuleTester } = require("eslint");
-const rule = require("../../../lib/rules/no-client-on-page");
+const rule = require("../../../lib/rules/no-use-client-on-page");
 
 const ruleTester = new RuleTester({
     parser: require.resolve("@babel/eslint-parser"),
@@ -28,6 +28,21 @@ ruleTester.run("no-client-on-page", rule, {
         const Pages = () => { return <div>Hello, Pages!</div>; };
       `,
             filename: "./app/components/pages.tsx",
+        },
+        // Case of 'app' folder root
+        {
+            code: `
+        import React from 'react';
+        const Page = () => { return <div>Hello, Page!</div>; };
+      `,
+            filename: "./app/page.ts",
+        },
+        {
+            code: `
+        import React from 'react';
+        const Pages = () => { return <div>Hello, Pages!</div>; };
+      `,
+            filename: "./app/pages.tsx",
         },
         // File not inside 'app' folder
         {
@@ -74,6 +89,25 @@ ruleTester.run("no-client-on-page", rule, {
         const Pages = () => { return <div>Hello, Pages!</div>; };
       `,
             filename: "./app/components/pages.tsx",
+            errors: [{ messageId: "noUseClient" }],
+        },
+        // Case of 'app' folder root
+        {
+            code: `
+        "use client";
+        import React from 'react';
+        const Page = () => { return <div>Hello, Page!</div>; };
+      `,
+            filename: "./app/page.ts",
+            errors: [{ messageId: "noUseClient" }],
+        },
+        {
+            code: `
+        "use client";
+        import React from 'react';
+        const Pages = () => { return <div>Hello, Pages!</div>; };
+      `,
+            filename: "./app/pages.tsx",
             errors: [{ messageId: "noUseClient" }],
         },
         // 'use client' in a '.js' file inside 'app' folder


### PR DESCRIPTION
Catch page using "use client" at the root of app folder & add test cases